### PR TITLE
[Not working] Use @generated to make recon type-inferable

### DIFF
--- a/src/reconstructor.jl
+++ b/src/reconstructor.jl
@@ -10,7 +10,7 @@ struct_as_dict(st) = [(n => getfield(st, n)) for n in fieldnames(typeof(st))]
 Re-construct `thing` with new field values specified by the keyword
 arguments.
 """
-function recon(thing; kwargs...)
+@generated function recon(thing; kwargs...)
     constructor = constructor_of(thing)
-    return constructor(; struct_as_dict(thing)..., kwargs...)
+    return :($constructor(; struct_as_dict(thing)..., kwargs...))
 end


### PR DESCRIPTION
This PR is for just noting a failed attempt to use `@generated`.

Once Julia can infer type of keyword-only constructor, it may be possible for `recon` to be inferred as well.  It probably requires `@generated` function but it turned out this approach does not work.  (It's the same approach I've tried in https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/89)

The problem is that `@generated` function has to be pure:

> Generated functions must not mutate or observe any non-constant global state (including, for example, IO, locks, non-local dictionaries, or using method_exists). This means they can only read global constants, and cannot have any side effects. In other words, they **must be completely pure**.
>
> --- https://docs.julialang.org/en/stable/manual/metaprogramming.html#Generated-functions-1

However, current approach is to use `constructor_of` for users to "register" their keyword-only constructors.  It makes `recon` a non-pure function.
